### PR TITLE
Fixing the accepted characters in entropy check

### DIFF
--- a/lib/modules/entropy/shannon.js
+++ b/lib/modules/entropy/shannon.js
@@ -4,9 +4,7 @@ module.exports = function Shannon() {
   // Create an array of character frequencies.
   const getFrequencies = str => {
     let dict = new Set(str);
-    return [...dict].map(chr => {
-      return str.match(new RegExp(chr, 'g')).length;
-    });
+    return [...dict].map(c=>str.split(c).length-1);
   };
 
   let self = {};


### PR DESCRIPTION
The regex match was ignoring regex reserved characters and/or causing errors